### PR TITLE
feat: Add close code and reason for vm client

### DIFF
--- a/lib/src/client/ws_client_vm.dart
+++ b/lib/src/client/ws_client_vm.dart
@@ -123,7 +123,10 @@ final class WebSocketClient$VM extends WebSocketClientBase {
           .listen(
             super.onReceivedData,
             onError: onError,
-            onDone: () => disconnect(1000, 'SUBSCRIPTION_CLOSED'),
+            onDone: () => disconnect(
+              _client?.closeCode ?? 1000,
+              _client?.closeReason ?? 'SUBSCRIPTION_CLOSED',
+            ),
             cancelOnError: false,
           );
       // coverage:ignore-end


### PR DESCRIPTION
`WebSocketClient$VM` was missing close code and reason which come from server when it closes the connection.